### PR TITLE
Fix: #6 Unable to select Flow

### DIFF
--- a/src/Model/Flow.php
+++ b/src/Model/Flow.php
@@ -53,6 +53,7 @@ class Flow extends DataObject
 
             $fields->removeByName([
                 'PathfinderID',
+                'Questions', // Questions can be accessed from the Pathfinder CMS tabs
             ]);
 
             // Title field


### PR DESCRIPTION
I determined that being able to edit Questions from the Flow CMS tabs may be a negative UX, so chose to remove the tab as a solution