### PR TITLE
Update for CMS 5 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
     ],
     "license": "BSD-3-Clause",
     "require": {
-        "silverstripe/framework": "^4.0 || ^5.0",
-        "silverstripe/admin": "^1.0 || ^2.0",
-        "silverstripe/taxonomy": "^2.0 || ^3.0 || ^4.0"
+        "silverstripe/framework": "^5.0",
+        "silverstripe/admin": "^2.0",
+        "silverstripe/taxonomy": "^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
     ],
     "license": "BSD-3-Clause",
     "require": {
-        "silverstripe/framework": "^5.0",
-        "silverstripe/admin": "^2.0",
-        "silverstripe/taxonomy": "^4.0"
+        "silverstripe/framework": "^4.0 || ^5.0",
+        "silverstripe/admin": "^1.0 || ^2.0",
+        "silverstripe/taxonomy": "^2.0 || ^3.0 || ^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
     ],
     "license": "BSD-3-Clause",
     "require": {
-        "silverstripe/framework": "^4.0",
-        "silverstripe/admin": "^1.0",
-        "silverstripe/taxonomy": "^2.0"
+        "silverstripe/framework": "^4.0 || ^5.0",
+        "silverstripe/admin": "^1.0 || ^2.0",
+        "silverstripe/taxonomy": "^2.0 || ^3.0 || ^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",

--- a/src/Model/Question.php
+++ b/src/Model/Question.php
@@ -189,7 +189,7 @@ class Question extends DataObject
             if ($flowField) {
                 // Restrict the range to only Flows for this question's Pathfinder
                 $flowField
-                    ->setSource($this->Pathfinder()->Flows()->map())
+                    ->setSource($this->Pathfinder()->Flows())
                     ->setEmptyString('Use default Flow');
             }
 


### PR DESCRIPTION
Updated the composer dependencies to include CMS 5 compatible versions. 

There is a slight change that I needed to make to fix an error in CMS5, where the $source for a dropdown field needs to be returned as a DataList rather than a map, but the change also appears to work in CMS 4.
